### PR TITLE
fix(i2c): correct 7-bit address logic and update examples

### DIFF
--- a/App/01_Snake/code/ch32x035_pioc_ws2812/sdk/Peripheral/inc/ch32x035_i2c.h
+++ b/App/01_Snake/code/ch32x035_pioc_ws2812/sdk/Peripheral/inc/ch32x035_i2c.h
@@ -299,7 +299,7 @@ void     I2C_GeneralCallCmd(I2C_TypeDef *I2Cx, FunctionalState NewState);
 void     I2C_ITConfig(I2C_TypeDef *I2Cx, uint16_t I2C_IT, FunctionalState NewState);
 void     I2C_SendData(I2C_TypeDef *I2Cx, uint8_t Data);
 uint8_t  I2C_ReceiveData(I2C_TypeDef *I2Cx);
-void     I2C_Send7bitAddress(I2C_TypeDef *I2Cx, uint8_t Address, uint8_t I2C_Direction);
+void     I2C_Send7bitAddress(I2C_TypeDef *I2Cx, uint8_t Address_7bit, uint8_t I2C_Direction);
 uint16_t I2C_ReadRegister(I2C_TypeDef *I2Cx, uint8_t I2C_Register);
 void     I2C_SoftwareResetCmd(I2C_TypeDef *I2Cx, FunctionalState NewState);
 void     I2C_NACKPositionConfig(I2C_TypeDef *I2Cx, uint16_t I2C_NACKPosition);

--- a/App/01_Snake/code/ch32x035_pioc_ws2812/sdk/Peripheral/src/ch32x035_i2c.c
+++ b/App/01_Snake/code/ch32x035_pioc_ws2812/sdk/Peripheral/src/ch32x035_i2c.c
@@ -457,7 +457,7 @@ uint8_t I2C_ReceiveData(I2C_TypeDef *I2Cx)
  * @brief   Transmits the address byte to select the slave device.
  *
  * @param   I2Cx - where x can be 1 to select the I2C peripheral.
- *          Address - specifies the slave address which will be transmitted.
+ *          Address_7bit - specifies the slave 7bit address which will be transmitted.
  *          I2C_Direction - specifies whether the I2C device will be a
  *        Transmitter or a Receiver.
  *            I2C_Direction_Transmitter - Transmitter mode.
@@ -465,8 +465,12 @@ uint8_t I2C_ReceiveData(I2C_TypeDef *I2Cx)
  *
  * @return  none
  */
-void I2C_Send7bitAddress(I2C_TypeDef *I2Cx, uint8_t Address, uint8_t I2C_Direction)
+void I2C_Send7bitAddress(I2C_TypeDef *I2Cx, uint8_t Address_7bit, uint8_t I2C_Direction)
 {
+    uint8_t Address;
+
+    Address = (Address_7bit & 0x7F) << 1;
+
     if(I2C_Direction != I2C_Direction_Transmitter)
     {
         Address |= OADDR1_ADD0_Set;

--- a/C++/Use MRS Create C++ project-example/CH32X035C8T6++/Peripheral/inc/ch32x035_i2c.h
+++ b/C++/Use MRS Create C++ project-example/CH32X035C8T6++/Peripheral/inc/ch32x035_i2c.h
@@ -299,7 +299,7 @@ void     I2C_GeneralCallCmd(I2C_TypeDef *I2Cx, FunctionalState NewState);
 void     I2C_ITConfig(I2C_TypeDef *I2Cx, uint16_t I2C_IT, FunctionalState NewState);
 void     I2C_SendData(I2C_TypeDef *I2Cx, uint8_t Data);
 uint8_t  I2C_ReceiveData(I2C_TypeDef *I2Cx);
-void     I2C_Send7bitAddress(I2C_TypeDef *I2Cx, uint8_t Address, uint8_t I2C_Direction);
+void     I2C_Send7bitAddress(I2C_TypeDef *I2Cx, uint8_t Address_7bit, uint8_t I2C_Direction);
 uint16_t I2C_ReadRegister(I2C_TypeDef *I2Cx, uint8_t I2C_Register);
 void     I2C_SoftwareResetCmd(I2C_TypeDef *I2Cx, FunctionalState NewState);
 void     I2C_NACKPositionConfig(I2C_TypeDef *I2Cx, uint16_t I2C_NACKPosition);

--- a/C++/Use MRS Create C++ project-example/CH32X035C8T6++/Peripheral/src/ch32x035_i2c.c
+++ b/C++/Use MRS Create C++ project-example/CH32X035C8T6++/Peripheral/src/ch32x035_i2c.c
@@ -457,7 +457,7 @@ uint8_t I2C_ReceiveData(I2C_TypeDef *I2Cx)
  * @brief   Transmits the address byte to select the slave device.
  *
  * @param   I2Cx - where x can be 1 to select the I2C peripheral.
- *          Address - specifies the slave address which will be transmitted.
+ *          Address_7bit - specifies the slave 7bit address which will be transmitted.
  *          I2C_Direction - specifies whether the I2C device will be a
  *        Transmitter or a Receiver.
  *            I2C_Direction_Transmitter - Transmitter mode.
@@ -465,8 +465,12 @@ uint8_t I2C_ReceiveData(I2C_TypeDef *I2Cx)
  *
  * @return  none
  */
-void I2C_Send7bitAddress(I2C_TypeDef *I2Cx, uint8_t Address, uint8_t I2C_Direction)
+void I2C_Send7bitAddress(I2C_TypeDef *I2Cx, uint8_t Address_7bit, uint8_t I2C_Direction)
 {
+    uint8_t Address;
+
+    Address = (Address_7bit & 0x7F) << 1;
+
     if(I2C_Direction != I2C_Direction_Transmitter)
     {
         Address |= OADDR1_ADD0_Set;

--- a/EVT/EXAM/I2C/I2C_10bit_Mode/User/main.c
+++ b/EVT/EXAM/I2C/I2C_10bit_Mode/User/main.c
@@ -112,10 +112,10 @@ int main(void)
 	I2C_GenerateSTART( I2C1, ENABLE );
 
 	while( !I2C_CheckEvent( I2C1, I2C_EVENT_MASTER_MODE_SELECT ) );
-	I2C_Send7bitAddress( I2C1, 0xF0, I2C_Direction_Transmitter );
+	I2C_Send7bitAddress( I2C1, 0x78, I2C_Direction_Transmitter );
 
 	while( !I2C_CheckEvent( I2C1, I2C_EVENT_MASTER_MODE_ADDRESS10 ) );
-	I2C_Send7bitAddress( I2C1, 0x02, I2C_Direction_Transmitter );
+	I2C_Send7bitAddress( I2C1, 0x01, I2C_Direction_Transmitter );
 
 	while( !I2C_CheckEvent( I2C1, I2C_EVENT_MASTER_TRANSMITTER_MODE_SELECTED ) );
 

--- a/EVT/EXAM/I2C/I2C_7bit_Interrupt_Mode/User/main.c
+++ b/EVT/EXAM/I2C/I2C_7bit_Interrupt_Mode/User/main.c
@@ -203,10 +203,10 @@ void I2C1_EV_IRQHandler(void )
       {
           if(master_sate == 0 ){
               master_sate = 1;
-              I2C_Send7bitAddress( I2C1, 0x02, I2C_Direction_Transmitter );
+              I2C_Send7bitAddress( I2C1, 0x01, I2C_Direction_Transmitter );
           }else{
               master_sate = 4;
-              I2C_Send7bitAddress( I2C1, 0x02, I2C_Direction_Receiver );
+              I2C_Send7bitAddress( I2C1, 0x01, I2C_Direction_Receiver );
           }
       }
 

--- a/EVT/EXAM/I2C/I2C_7bit_Mode/User/main.c
+++ b/EVT/EXAM/I2C/I2C_7bit_Mode/User/main.c
@@ -112,7 +112,7 @@ int main(void)
 	I2C_GenerateSTART( I2C1, ENABLE );
 
 	while( !I2C_CheckEvent( I2C1, I2C_EVENT_MASTER_MODE_SELECT ) );
-	I2C_Send7bitAddress( I2C1, 0x02, I2C_Direction_Transmitter );
+	I2C_Send7bitAddress( I2C1, 0x01, I2C_Direction_Transmitter );
 
     while( !I2C_CheckEvent( I2C1, I2C_EVENT_MASTER_TRANSMITTER_MODE_SELECTED ) );
  

--- a/EVT/EXAM/I2C/I2C_DMA/User/main.c
+++ b/EVT/EXAM/I2C/I2C_DMA/User/main.c
@@ -194,7 +194,7 @@ int main(void)
     I2C_GenerateSTART( I2C1, ENABLE );
 
 	while( !I2C_CheckEvent( I2C1, I2C_EVENT_MASTER_MODE_SELECT ) );
-	I2C_Send7bitAddress( I2C1, 0x02, I2C_Direction_Transmitter );
+	I2C_Send7bitAddress( I2C1, 0x01, I2C_Direction_Transmitter );
 
 	while( !I2C_CheckEvent( I2C1, I2C_EVENT_MASTER_TRANSMITTER_MODE_SELECTED ) );
 

--- a/EVT/EXAM/I2C/I2C_EEPROM/User/main.c
+++ b/EVT/EXAM/I2C/I2C_EEPROM/User/main.c
@@ -112,7 +112,7 @@ u8 AT24CXX_ReadOneByte(u16 ReadAddr)
 	I2C_GenerateSTART( I2C1, ENABLE );
 
 	while( !I2C_CheckEvent( I2C1, I2C_EVENT_MASTER_MODE_SELECT ) );
-	I2C_Send7bitAddress( I2C1, 0XA0, I2C_Direction_Transmitter );
+	I2C_Send7bitAddress( I2C1, 0X50, I2C_Direction_Transmitter );
 
 	while( !I2C_CheckEvent( I2C1, I2C_EVENT_MASTER_TRANSMITTER_MODE_SELECTED ) );
 
@@ -132,7 +132,7 @@ u8 AT24CXX_ReadOneByte(u16 ReadAddr)
 	I2C_GenerateSTART( I2C1, ENABLE );
 
 	while( !I2C_CheckEvent( I2C1, I2C_EVENT_MASTER_MODE_SELECT ) );
-	I2C_Send7bitAddress( I2C1, 0XA0, I2C_Direction_Receiver );
+	I2C_Send7bitAddress( I2C1, 0X50, I2C_Direction_Receiver );
 
 	while( !I2C_CheckEvent( I2C1, I2C_EVENT_MASTER_RECEIVER_MODE_SELECTED ) );
   while( I2C_GetFlagStatus( I2C1, I2C_FLAG_RXNE ) ==  RESET )
@@ -159,7 +159,7 @@ void AT24CXX_WriteOneByte(u16 WriteAddr, u8 DataToWrite)
 	I2C_GenerateSTART( I2C1, ENABLE );
 
 	while( !I2C_CheckEvent( I2C1, I2C_EVENT_MASTER_MODE_SELECT ) );
-	I2C_Send7bitAddress( I2C1, 0XA0, I2C_Direction_Transmitter );
+	I2C_Send7bitAddress( I2C1, 0X50, I2C_Direction_Transmitter );
 
 	while( !I2C_CheckEvent( I2C1, I2C_EVENT_MASTER_TRANSMITTER_MODE_SELECTED ) );
 

--- a/EVT/EXAM/I2C/I2C_PEC/User/main.c
+++ b/EVT/EXAM/I2C/I2C_PEC/User/main.c
@@ -124,7 +124,7 @@ int main(void)
     I2C_GenerateSTART(I2C1, ENABLE);
 
     while(!I2C_CheckEvent(I2C1, I2C_EVENT_MASTER_MODE_SELECT));
-    I2C_Send7bitAddress(I2C1, 0x02, I2C_Direction_Transmitter);
+    I2C_Send7bitAddress(I2C1, 0x01, I2C_Direction_Transmitter);
 
     while(!I2C_CheckEvent(I2C1, I2C_EVENT_MASTER_TRANSMITTER_MODE_SELECTED));
 

--- a/EVT/EXAM/SRC/Peripheral/inc/ch32x035_i2c.h
+++ b/EVT/EXAM/SRC/Peripheral/inc/ch32x035_i2c.h
@@ -299,7 +299,7 @@ void     I2C_GeneralCallCmd(I2C_TypeDef *I2Cx, FunctionalState NewState);
 void     I2C_ITConfig(I2C_TypeDef *I2Cx, uint16_t I2C_IT, FunctionalState NewState);
 void     I2C_SendData(I2C_TypeDef *I2Cx, uint8_t Data);
 uint8_t  I2C_ReceiveData(I2C_TypeDef *I2Cx);
-void     I2C_Send7bitAddress(I2C_TypeDef *I2Cx, uint8_t Address, uint8_t I2C_Direction);
+void     I2C_Send7bitAddress(I2C_TypeDef *I2Cx, uint8_t Address_7bit, uint8_t I2C_Direction);
 uint16_t I2C_ReadRegister(I2C_TypeDef *I2Cx, uint8_t I2C_Register);
 void     I2C_SoftwareResetCmd(I2C_TypeDef *I2Cx, FunctionalState NewState);
 void     I2C_NACKPositionConfig(I2C_TypeDef *I2Cx, uint16_t I2C_NACKPosition);

--- a/EVT/EXAM/SRC/Peripheral/src/ch32x035_i2c.c
+++ b/EVT/EXAM/SRC/Peripheral/src/ch32x035_i2c.c
@@ -457,7 +457,7 @@ uint8_t I2C_ReceiveData(I2C_TypeDef *I2Cx)
  * @brief   Transmits the address byte to select the slave device.
  *
  * @param   I2Cx - where x can be 1 to select the I2C peripheral.
- *          Address - specifies the slave address which will be transmitted.
+ *          Address_7bit - specifies the slave 7bit address which will be transmitted.
  *          I2C_Direction - specifies whether the I2C device will be a
  *        Transmitter or a Receiver.
  *            I2C_Direction_Transmitter - Transmitter mode.
@@ -465,8 +465,12 @@ uint8_t I2C_ReceiveData(I2C_TypeDef *I2Cx)
  *
  * @return  none
  */
-void I2C_Send7bitAddress(I2C_TypeDef *I2Cx, uint8_t Address, uint8_t I2C_Direction)
+void I2C_Send7bitAddress(I2C_TypeDef *I2Cx, uint8_t Address_7bit, uint8_t I2C_Direction)
 {
+    uint8_t Address;
+
+    Address = (Address_7bit & 0x7F) << 1;
+
     if(I2C_Direction != I2C_Direction_Transmitter)
     {
         Address |= OADDR1_ADD0_Set;


### PR DESCRIPTION
## 📝 Description
This PR fixes a discrepancy in the `I2C_Send7bitAddress` function where the implementation did not match its name. It also updates the example files to align with the corrected API.

## 🛠️ Changes
- **fix(i2c):** Refactored `I2C_Send7bitAddress` to properly handle 7-bit addresses (performing the left-shift internally).
- **refactor(example):** Updated all example files to pass 7-bit addresses (e.g., `0xA0→0x50`) instead of 8-bit addresses, adhering to the new interface standard.

## ✅ Verification
- Verified that the I2C address is now correctly shifted and the R/W bit is set properly.
- Confirmed that example projects compile and logic aligns with the driver updates.